### PR TITLE
Fix "Symbol's function definition is void: alist-get"

### DIFF
--- a/devdocs.el
+++ b/devdocs.el
@@ -85,7 +85,7 @@ It builds search pattern base on some context."
 
 (defun devdocs-build-search-pattern-function ()
   "Build search pattern base on region/symbol-at-point and major-mode."
-  (let ((documentation (alist-get major-mode devdocs-alist))
+  (let ((documentation (cdr (assoc major-mode devdocs-alist)))
         (query (if (use-region-p)
                    (buffer-substring (region-beginning) (region-end))
                  (thing-at-point 'symbol))))


### PR DESCRIPTION
When I run `devdocs-search` I get the following error:

```
Symbol's function definition is void: alist-get
```

It seems that function isn't defined in my version of emacs (24.5.1). An equivalent way of doing the same thing is using `cdr` and `assoc` which I've used here.
